### PR TITLE
fix: Run git ls-files relative to cwd

### DIFF
--- a/lua/git-link/main.lua
+++ b/lua/git-link/main.lua
@@ -80,13 +80,15 @@ local function get_line_range()
 end
 
 local function get_url()
-	local git_root = vim.fn.trim(vim.fn.system("git rev-parse --show-toplevel"))
+	-- Call to git rev-parse as a way to ensure this is a valid git repo
+	vim.fn.trim(vim.fn.system("git rev-parse --show-toplevel"))
 	if vim.v.shell_error ~= 0 then
 		vim.notify("Not a git repository", vim.log.levels.ERROR)
 		return nil
 	end
 
-	local filename = vim.fn.expand("%:p"):gsub("\\", "/"):gsub("^" .. git_root:gsub("\\", "/") .. "/", "")
+	local cwd = vim.fn.getcwd()
+	local filename = vim.fn.expand("%:p"):gsub("\\", "/"):gsub("^" .. cwd:gsub("\\", "/") .. "/", "")
 
 	local relative_filename = vim.fn.trim(vim.fn.system("git ls-files --full-name " .. filename))
 	if vim.v.shell_error ~= 0 or relative_filename == "" then


### PR DESCRIPTION
What is this change?
--------------------

- Change is limited to `get_url`
- Modifies the working dir used for the `git ls-files` command
- Keep the command `git rev-parse` at the top of `get_url` as a way to be srue this is a git dir

Why do we want this?
--------------------

- `Git ls-files --full-name` requires param relative to cwd
- The `--full-name` refers to the output, i.e. the file is listed with its full name
- The param [filename] must be relative to the current dir
- This only affects workspaces that are subdirectories

Any weird quirks?
-----------------

Funny you should ask! I considered using another git commmand after some googling, and I found [this StackOverflow answer](https://stackoverflow.com/questions/59342596/how-to-check-if-it-is-a-valid-git-repo).

The answer references a command that seemed like a good candidate, `git rev-parse --is-inside-work-tree`. This command prints `true` inside a work tree or a normal repo, prints `false` inside the `.git` directory, and returns a non-zero status if not in any kind of git dir.

On the other hand, `git rev-parse --show-toplevel` will error in the `.git` dir, reeturn zero status in a working dir, and error outside of any kind of git dir. I figured the current behavior relying on the error code makes the most sense, so I left it.

I tested this out in a few different workspaces on my machine, which have some weird properties like using worktrees and having a bare repo, worktrees, and sparse checkouts. This version of the command works with `<leader>go` and `<leader>gc` for open/copy.