### PR TITLE
Add remote ref fallback and permalinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - **Get a sharable URL**: Easily generate a link to the line of code under your cursor, ready to share. You can also share a link to a line range, if you select a visual block.
 - **Open in Browser**: Instantly open the browser and navigate to the specific line of code under your cursor.
+- **Permalinks**: Copy or open a SHA-pinned link when your current `HEAD` is present on the remote.
 - **Configurable URL Rules**: Support for custom Git hosting platforms through configurable URL rewriting rules.
 
 ## Installation and Configuration
@@ -14,6 +15,8 @@ This plugin does not set any default keymaps, however, in the following examples
 
 - `<leader>gu`: Copies the URL of the line of code under your cursor to your clipboard.
 - `<leader>go`: Opens the browser and navigates directly to the line of code under your cursor.
+- `<leader>gp`: Copies a permalink for the line of code under your cursor to your clipboard.
+- `<leader>gP`: Opens a permalink for the line of code under your cursor in your browser.
 
 Below are examples for different setups:
 
@@ -35,6 +38,18 @@ Below are examples for different setups:
       desc = "Open code link in browser",
       mode = { "n", "x" }
     },
+    {
+      "<leader>gp",
+      function() require("git-link.main").copy_permalink() end,
+      desc = "Copy code permalink to clipboard",
+      mode = { "n", "x" }
+    },
+    {
+      "<leader>gP",
+      function() require("git-link.main").open_permalink() end,
+      desc = "Open code permalink in browser",
+      mode = { "n", "x" }
+    },
   },
 }
 ```
@@ -48,8 +63,12 @@ use {
     -- Set up your keymaps
     vim.keymap.set('n', '<leader>gu', function() require("git-link.main").copy_line_url() end)
     vim.keymap.set('n', '<leader>go', function() require("git-link.main").open_line_url() end)
+    vim.keymap.set('n', '<leader>gp', function() require("git-link.main").copy_permalink() end)
+    vim.keymap.set('n', '<leader>gP', function() require("git-link.main").open_permalink() end)
     vim.keymap.set('x', '<leader>gu', function() require("git-link.main").copy_line_url() end)
     vim.keymap.set('x', '<leader>go', function() require("git-link.main").open_line_url() end)
+    vim.keymap.set('x', '<leader>gp', function() require("git-link.main").copy_permalink() end)
+    vim.keymap.set('x', '<leader>gP', function() require("git-link.main").open_permalink() end)
   end
 }
 ```
@@ -60,9 +79,19 @@ use {
 -- In your init.lua
 vim.keymap.set('n', '<leader>gu', function() require("git-link.main").copy_line_url() end)
 vim.keymap.set('n', '<leader>go', function() require("git-link.main").open_line_url() end)
+vim.keymap.set('n', '<leader>gp', function() require("git-link.main").copy_permalink() end)
+vim.keymap.set('n', '<leader>gP', function() require("git-link.main").open_permalink() end)
 vim.keymap.set('x', '<leader>gu', function() require("git-link.main").copy_line_url() end)
 vim.keymap.set('x', '<leader>go', function() require("git-link.main").open_line_url() end)
+vim.keymap.set('x', '<leader>gp', function() require("git-link.main").copy_permalink() end)
+vim.keymap.set('x', '<leader>gP', function() require("git-link.main").open_permalink() end)
 ```
+
+### Link Refs
+
+`copy_line_url()` and `open_line_url()` use a branch name from `origin`. If your local branch has unpushed commits, the plugin chooses the closest branch on `origin` that shares history with `HEAD`, preferring the current branch's upstream, then `origin/HEAD`, then any other matching remote branch.
+
+`copy_permalink()` and `open_permalink()` use the full `HEAD` SHA. They only work when `HEAD` is present on `origin`; otherwise the plugin reports an error instead of creating a link to a commit the remote may not resolve.
 
 ### Default URL Rules
 
@@ -82,7 +111,9 @@ You can add custom URL rules to support different Git hosting platforms. Each ru
 - `format_url`: A function that generates the final browser URL using:
   - `base_url`: The resulting URL after replacing the pattern
   - `params`: A table containing:
-    - `branch`: Current git branch
+    - `branch`: Selected branch name, or the commit SHA for permalink calls
+    - `ref`: Same value as `branch`
+    - `permalink`: Boolean indicating whether the caller requested a permalink
     - `file_path`: Path to the file
     - `start_line`: Starting line number
     - `end_line`: Ending line number (same as start_line for single line links)

--- a/lua/git-link/init.lua
+++ b/lua/git-link/init.lua
@@ -9,5 +9,7 @@ end
 
 M.copy_line_url = main.copy_line_url
 M.open_line_url = main.open_line_url
+M.copy_permalink = main.copy_permalink
+M.open_permalink = main.open_permalink
 
 return M

--- a/lua/git-link/main.lua
+++ b/lua/git-link/main.lua
@@ -3,6 +3,33 @@ local config = require("git-link.config")
 -- Cache OS detection at module load time
 local os_name = jit and jit.os or ""
 
+local function redirect_stderr_to_null(command)
+	if os_name == "Windows" then
+		return command .. " 2>NUL"
+	end
+	return command .. " 2>/dev/null"
+end
+
+local function shellescape(value)
+	return vim.fn.shellescape(value)
+end
+
+local function git_output(command)
+	local output = vim.fn.system(redirect_stderr_to_null("git " .. command))
+	if vim.v.shell_error ~= 0 then
+		return nil
+	end
+	return vim.fn.trim(output)
+end
+
+local function git_output_lines(command)
+	local output = vim.fn.systemlist(redirect_stderr_to_null("git " .. command))
+	if vim.v.shell_error ~= 0 then
+		return nil
+	end
+	return output
+end
+
 local function copy_to_clipboard(text)
 	vim.fn.setreg("+", text)
 	vim.notify("Git URL copied to clipboard", vim.log.levels.INFO)
@@ -39,39 +66,172 @@ local function open_url_in_browser(url)
 	})
 
 	if job_id <= 0 then
-		vim.notify(
-			string.format("Failed to start browser command: %s", command),
-			vim.log.levels.ERROR
-		)
+		vim.notify(string.format("Failed to start browser command: %s", command), vim.log.levels.ERROR)
 		return
 	end
 
 	vim.notify("Opening git URL in browser", vim.log.levels.INFO)
 end
 
-local function get_current_branch()
-	local command
-	if os_name == "Windows" then
-		command = "git rev-parse --abbrev-ref @{u} 2>NUL"
-	else
-		command = "git rev-parse --abbrev-ref @{u} 2>/dev/null"
-	end
-
-	local output = vim.fn.system(command)
-	if vim.v.shell_error ~= 0 then
-		vim.notify("Could not determine upstream branch (no tracking branch set?), falling back to 'master'", vim.log.levels.WARN)
-		return "master"
-	end
-
-	local branch = vim.fn.trim(output)
-	local _, branch_name = branch:match("^([^/]+)/(.+)$")
-	return branch_name or "master"
+local function remote_ref_prefix(remote_name)
+	return "refs/remotes/" .. remote_name .. "/"
 end
 
-local function get_remote_url()
-	local remote_url = vim.fn.trim(vim.fn.system("git config --get remote.origin.url"))
-	if vim.v.shell_error ~= 0 then
-		vim.notify("No remote 'origin' found. Run 'git remote -v' to check configured remotes", vim.log.levels.ERROR)
+local function is_remote_ref(remote_ref, remote_name)
+	local prefix = remote_ref_prefix(remote_name)
+	return remote_ref:sub(1, #prefix) == prefix
+end
+
+local function get_upstream_ref(remote_name)
+	local upstream_ref = git_output("rev-parse --symbolic-full-name @{u}")
+	if not upstream_ref or upstream_ref == "" or not is_remote_ref(upstream_ref, remote_name) then
+		return nil
+	end
+	return upstream_ref
+end
+
+local function get_remote_head_target(remote_name)
+	return git_output("symbolic-ref --quiet " .. shellescape(remote_ref_prefix(remote_name) .. "HEAD"))
+end
+
+local function list_remote_refs(remote_name)
+	local refs = git_output_lines(
+		string.format('for-each-ref --format="%%(refname)" %s', shellescape("refs/remotes/" .. remote_name))
+	)
+	if not refs then
+		return {}
+	end
+
+	local unique_refs = {}
+	local seen = {}
+	for _, remote_ref in ipairs(refs) do
+		remote_ref = vim.fn.trim(remote_ref)
+		if remote_ref ~= "" and not seen[remote_ref] then
+			seen[remote_ref] = true
+			table.insert(unique_refs, remote_ref)
+		end
+	end
+	return unique_refs
+end
+
+local function remote_ref_priority(remote_ref, upstream_ref, remote_head_ref, remote_head_target)
+	if upstream_ref and remote_ref == upstream_ref then
+		return 1
+	end
+	if remote_ref == remote_head_ref or (remote_head_target and remote_ref == remote_head_target) then
+		return 2
+	end
+	return 3
+end
+
+local function score_remote_ref(remote_ref, upstream_ref, remote_head_ref, remote_head_target)
+	local merge_base = git_output("merge-base HEAD " .. shellescape(remote_ref))
+	if not merge_base or merge_base == "" then
+		return nil
+	end
+
+	local distance_output = git_output("rev-list --count " .. shellescape(merge_base .. "..HEAD"))
+	local distance = tonumber(distance_output)
+	if not distance then
+		return nil
+	end
+
+	return {
+		ref = remote_ref,
+		distance = distance,
+		priority = remote_ref_priority(remote_ref, upstream_ref, remote_head_ref, remote_head_target),
+	}
+end
+
+local function is_better_remote_ref(candidate, current)
+	if not current then
+		return true
+	end
+	if candidate.distance ~= current.distance then
+		return candidate.distance < current.distance
+	end
+	if candidate.priority ~= current.priority then
+		return candidate.priority < current.priority
+	end
+	return candidate.ref < current.ref
+end
+
+local function get_closest_remote_ref(remote_name)
+	local upstream_ref = get_upstream_ref(remote_name)
+	local remote_head_ref = remote_ref_prefix(remote_name) .. "HEAD"
+	local remote_head_target = get_remote_head_target(remote_name)
+	local best
+
+	for _, remote_ref in ipairs(list_remote_refs(remote_name)) do
+		local candidate = score_remote_ref(remote_ref, upstream_ref, remote_head_ref, remote_head_target)
+		if candidate and is_better_remote_ref(candidate, best) then
+			best = candidate
+		end
+	end
+
+	return best and best.ref or nil
+end
+
+local function remote_ref_to_branch(remote_ref, remote_name)
+	local prefix = remote_ref_prefix(remote_name)
+	if remote_ref == prefix .. "HEAD" then
+		remote_ref = get_remote_head_target(remote_name) or remote_ref
+	end
+	if not is_remote_ref(remote_ref, remote_name) then
+		return nil
+	end
+	return remote_ref:sub(#prefix + 1)
+end
+
+local function get_current_branch(remote_name)
+	local remote_ref = get_closest_remote_ref(remote_name)
+	if not remote_ref then
+		vim.notify(
+			string.format("Could not determine a branch on remote '%s' that shares history with HEAD", remote_name),
+			vim.log.levels.ERROR
+		)
+		return nil
+	end
+
+	local branch = remote_ref_to_branch(remote_ref, remote_name)
+	if not branch or branch == "" or branch == "HEAD" then
+		vim.notify(string.format("Could not resolve remote '%s' HEAD to a branch", remote_name), vim.log.levels.ERROR)
+		return nil
+	end
+
+	return branch
+end
+
+local function get_permalink_ref(remote_name)
+	local refs = git_output_lines(
+		string.format(
+			'for-each-ref --contains HEAD --format="%%(refname)" %s',
+			shellescape("refs/remotes/" .. remote_name)
+		)
+	)
+	if refs then
+		for _, remote_ref in ipairs(refs) do
+			if vim.fn.trim(remote_ref) ~= "" then
+				return git_output("rev-parse HEAD")
+			end
+		end
+	end
+
+	vim.notify(
+		string.format("HEAD is not present on remote '%s'. Push or fetch before creating a permalink", remote_name),
+		vim.log.levels.ERROR
+	)
+	return nil
+end
+
+local function get_remote_url(remote_name)
+	remote_name = remote_name or "origin"
+	local remote_url = git_output("config --get " .. shellescape("remote." .. remote_name .. ".url"))
+	if not remote_url or remote_url == "" then
+		vim.notify(
+			string.format("No remote '%s' found. Run 'git remote -v' to check configured remotes", remote_name),
+			vim.log.levels.ERROR
+		)
 		return nil
 	end
 
@@ -81,7 +241,7 @@ local function get_remote_url()
 	for _, rule in ipairs(rules) do
 		if remote_url:match(rule.pattern) then
 			local final_url = remote_url:gsub(rule.pattern, rule.replace):gsub("%.git$", "")
-			return final_url, rule.format_url
+			return final_url, rule.format_url, remote_name
 		end
 	end
 
@@ -102,10 +262,11 @@ local function get_line_range()
 	return current[2], current[2]
 end
 
-local function get_url()
+local function get_url(opts)
+	opts = opts or {}
+
 	-- Call to git rev-parse as a way to ensure this is a valid git repo
-	vim.fn.trim(vim.fn.system("git rev-parse --show-toplevel"))
-	if vim.v.shell_error ~= 0 then
+	if not git_output("rev-parse --show-toplevel") then
 		vim.notify("Current directory is not inside a git repository", vim.log.levels.ERROR)
 		return nil
 	end
@@ -113,22 +274,33 @@ local function get_url()
 	local cwd = vim.fn.getcwd()
 	local filename = vim.fn.expand("%:p"):gsub("\\", "/"):gsub("^" .. cwd:gsub("\\", "/") .. "/", "")
 
-	local relative_filename = vim.fn.trim(vim.fn.system("git ls-files --full-name " .. filename))
-	if vim.v.shell_error ~= 0 or relative_filename == "" then
+	local relative_filename = git_output("ls-files --full-name " .. shellescape(filename))
+	if not relative_filename or relative_filename == "" then
 		vim.notify(string.format("File '%s' is not tracked by git", filename), vim.log.levels.ERROR)
 		return nil
 	end
 
-	local remote_url, format_url = get_remote_url()
-	if not remote_url or not format_url then
+	local remote_url, format_url, remote_name = get_remote_url()
+	if not remote_url or not format_url or not remote_name then
 		return nil
 	end
 
-	local branch = get_current_branch()
+	local ref
+	if opts.permalink then
+		ref = get_permalink_ref(remote_name)
+	else
+		ref = get_current_branch(remote_name)
+	end
+	if not ref then
+		return nil
+	end
+
 	local start_line, end_line = get_line_range()
 
 	local params = {
-		branch = branch,
+		branch = ref,
+		ref = ref,
+		permalink = opts.permalink == true,
 		file_path = relative_filename,
 		start_line = start_line,
 		end_line = end_line,
@@ -150,7 +322,29 @@ local function open_line_url()
 	end
 end
 
+local function copy_permalink()
+	local url = get_url({ permalink = true })
+	if url then
+		copy_to_clipboard(url)
+	end
+end
+
+local function open_permalink()
+	local url = get_url({ permalink = true })
+	if url then
+		open_url_in_browser(url)
+	end
+end
+
 return {
 	copy_line_url = copy_line_url,
 	open_line_url = open_line_url,
+	copy_permalink = copy_permalink,
+	open_permalink = open_permalink,
+	_private = {
+		get_closest_remote_ref = get_closest_remote_ref,
+		get_current_branch = get_current_branch,
+		get_permalink_ref = get_permalink_ref,
+		remote_ref_to_branch = remote_ref_to_branch,
+	},
 }

--- a/tests/main_spec.lua
+++ b/tests/main_spec.lua
@@ -1,4 +1,5 @@
 local git_link = require("git-link")
+local main = require("git-link.main")
 local config = require("git-link.config")
 
 describe("git-link", function()
@@ -17,6 +18,14 @@ describe("git-link", function()
 
 		it("should export open_line_url function", function()
 			assert.is_function(git_link.open_line_url)
+		end)
+
+		it("should export copy_permalink function", function()
+			assert.is_function(git_link.copy_permalink)
+		end)
+
+		it("should export open_permalink function", function()
+			assert.is_function(git_link.open_permalink)
 		end)
 	end)
 
@@ -72,6 +81,128 @@ describe("git-link", function()
 				git_link.copy_line_url()
 			end)
 		end)
+	end)
+end)
+
+describe("remote ref selection", function()
+	local original_dir
+	local temp_dirs
+
+	local function run(command, cwd)
+		local previous_dir = vim.fn.getcwd()
+		if cwd then
+			vim.cmd("cd " .. vim.fn.fnameescape(cwd))
+		end
+
+		local output = vim.fn.system(command)
+		local exit_code = vim.v.shell_error
+
+		if cwd then
+			vim.cmd("cd " .. vim.fn.fnameescape(previous_dir))
+		end
+
+		assert.equals(0, exit_code, "Command failed: " .. command .. "\n" .. output)
+		return vim.fn.trim(output)
+	end
+
+	local function create_repo()
+		local root = vim.fn.tempname()
+		local origin = root .. "/origin.git"
+		local worktree = root .. "/worktree"
+
+		vim.fn.mkdir(root, "p")
+		table.insert(temp_dirs, root)
+
+		run("git init --bare " .. vim.fn.shellescape(origin))
+		run("git init " .. vim.fn.shellescape(worktree))
+		run("git config user.email test@example.com", worktree)
+		run("git config user.name Tester", worktree)
+
+		vim.fn.writefile({ "line one" }, worktree .. "/file.lua")
+		run("git add file.lua", worktree)
+		run("git commit -m initial", worktree)
+		run("git branch -M main", worktree)
+		run("git remote add origin " .. vim.fn.shellescape(origin), worktree)
+		run("git push -u origin main", worktree)
+		run("git remote set-head origin main", worktree)
+
+		return {
+			origin = origin,
+			worktree = worktree,
+		}
+	end
+
+	before_each(function()
+		original_dir = vim.fn.getcwd()
+		temp_dirs = {}
+	end)
+
+	after_each(function()
+		vim.cmd("cd " .. vim.fn.fnameescape(original_dir))
+		for _, temp_dir in ipairs(temp_dirs) do
+			vim.fn.delete(temp_dir, "rf")
+		end
+	end)
+
+	it("uses origin HEAD for an unpushed local branch off main", function()
+		local repo = create_repo()
+		run("git checkout -b feature/local", repo.worktree)
+		vim.fn.writefile({ "line one", "local change" }, repo.worktree .. "/file.lua")
+		run("git add file.lua", repo.worktree)
+		run("git commit -m local-change", repo.worktree)
+
+		vim.cmd("cd " .. vim.fn.fnameescape(repo.worktree))
+
+		assert.equals("main", main._private.get_current_branch("origin"))
+	end)
+
+	it("uses the closest remote branch for an unpushed local branch", function()
+		local repo = create_repo()
+		run("git checkout -b v1.2.x main", repo.worktree)
+		vim.fn.writefile({ "line one", "release change" }, repo.worktree .. "/file.lua")
+		run("git add file.lua", repo.worktree)
+		run("git commit -m release-change", repo.worktree)
+		run("git push -u origin v1.2.x", repo.worktree)
+
+		run("git checkout -b hotfix/local", repo.worktree)
+		vim.fn.writefile({ "line one", "release change", "hotfix change" }, repo.worktree .. "/file.lua")
+		run("git add file.lua", repo.worktree)
+		run("git commit -m hotfix-change", repo.worktree)
+
+		vim.cmd("cd " .. vim.fn.fnameescape(repo.worktree))
+
+		assert.equals("v1.2.x", main._private.get_current_branch("origin"))
+	end)
+
+	it("prefers the current branch upstream when remote refs tie", function()
+		local repo = create_repo()
+		run("git checkout -b tracked main", repo.worktree)
+		run("git push -u origin tracked", repo.worktree)
+
+		vim.cmd("cd " .. vim.fn.fnameescape(repo.worktree))
+
+		assert.equals("tracked", main._private.get_current_branch("origin"))
+	end)
+
+	it("returns HEAD sha for permalinks when HEAD is on origin", function()
+		local repo = create_repo()
+		local head_sha = run("git rev-parse HEAD", repo.worktree)
+
+		vim.cmd("cd " .. vim.fn.fnameescape(repo.worktree))
+
+		assert.equals(head_sha, main._private.get_permalink_ref("origin"))
+	end)
+
+	it("does not return a permalink ref when HEAD is not on origin", function()
+		local repo = create_repo()
+		run("git checkout -b feature/local", repo.worktree)
+		vim.fn.writefile({ "line one", "local change" }, repo.worktree .. "/file.lua")
+		run("git add file.lua", repo.worktree)
+		run("git commit -m local-change", repo.worktree)
+
+		vim.cmd("cd " .. vim.fn.fnameescape(repo.worktree))
+
+		assert.is_nil(main._private.get_permalink_ref("origin"))
 	end)
 end)
 


### PR DESCRIPTION
## Summary
- choose the closest resolvable origin branch for normal line links, with upstream and origin/HEAD tie-breakers
- add copy/open permalink APIs that use HEAD SHA only when HEAD exists on origin
- document the new behavior and cover it with git fixture tests

https://github.com/juacker/git-link.nvim/issues/8